### PR TITLE
use clap to handle the command line options and thiserror to deal with the errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,25 +3,140 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628a8f9bd1e24b4e0db2b4bc2d000b001e7dd032d54afa60a68836aeec5aa54a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "cargo-samply"
 version = "0.1.6"
 dependencies = [
  "cargo_toml",
- "json",
- "serde",
- "serde_json",
+ "clap",
+ "log",
+ "ocli",
+ "thiserror",
  "toml",
 ]
 
 [[package]]
 name = "cargo_toml"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a969e13a7589e9e3e4207e153bae624ade2b5622fb4684a4923b23ec3d57719"
+checksum = "802b755090e39835a4b0440fb0bbee0df7495a8b337f63db21e616f7821c7e8c"
 dependencies = [
  "serde",
  "toml",
 ]
+
+[[package]]
+name = "clap"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "equivalent"
@@ -36,6 +151,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,22 +176,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.10"
+name = "libc"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
-name = "json"
-version = "0.12.4"
+name = "log"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
+name = "ocli"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd2eceb0ba04d1ebca6bd8e982915192f0d7e2ab83410dc1dfd676e0e702878"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "log",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -82,25 +223,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
-
-[[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -108,24 +243,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.111"
+name = "serde_spanned"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
- "itoa",
- "ryu",
  "serde",
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.5"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
-dependencies = [
- "serde",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -139,12 +269,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
- "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -180,10 +329,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "winnow"
-version = "0.5.34"
+name = "utf8parse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "winnow"
+version = "0.5.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67b5f0a4e7a27a64c651977932b9dc5667ca7fc31ac44b03ed37a0cf42fdfff"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,13 @@ homepage = "https://github.com/PhilippPolterauer/cargo-samply.git"
 documentation = "https://github.com/PhilippPolterauer/cargo-samply.git"
 
 [dependencies]
-cargo_toml = "0.17.1"
-json = "0.12.4"
-serde = "1.0.193"
-serde_json = "1.0.108"
-
-[dependencies.toml]
-version = "0.8.8"
-features = ["preserve_order"]
+cargo_toml = "0.18.0"
+thiserror = "1.0.56"
+clap = { version = "4.4.12", features = ["derive"] }
+log = { version = "0.4", features = ["std"] }
+toml = { version = "0.8.8" }
+ocli = "0.1.0"
 
 [profile.samply]
 inherits = "release"
 debug = true
-

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,34 @@
+use clap::Parser;
+
+/// A cargo subcommand for profiling binaries using samply
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Config {
+    /// Trailing arguments passed to the binary being profiled
+    #[arg(name = "TRAILING_ARGUMENTS")]
+    pub args: Vec<String>,
+
+    /// Build with the specified profile
+    #[arg(short, long, default_value = "samply")]
+    pub profile: String,
+
+    /// Binary to run
+    #[arg(short, long)]
+    pub bin: Option<String>,
+
+    /// Example to run
+    #[arg(short, long)]
+    pub example: Option<String>,
+
+    /// Build features to enable
+    #[arg(short, long)]
+    pub features: Option<String>,
+
+    /// Disable default features
+    #[arg(long)]
+    pub no_default_features: bool,
+
+    /// Print extra output to help debug problems
+    #[arg(short, long, default_value_t = false)]
+    pub verbose: bool,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,48 @@
+use std::io;
+use std::path::PathBuf;
+use std::result;
+use std::str::Utf8Error;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("{path}: {source}")]
+    PathIo { source: io::Error, path: PathBuf },
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Logger(#[from] log::SetLoggerError),
+    #[error(transparent)]
+    Utf8(#[from] Utf8Error),
+    #[error(transparent)]
+    TomlDeserialization(#[from] toml::de::Error),
+    #[error(transparent)]
+    TomlManifest(#[from] cargo_toml::Error),
+    #[error("--bin and --example are mutually exclusive")]
+    BinAndExampleMutuallyExclusive,
+    #[error("Build failed")]
+    CargoBuildFailed,
+    #[error("No binary found in 'Cargo.toml'")]
+    NoBinaryFound,
+    #[error("The binary to run can't be determined. Use the `--bin` option to specify a binary, or the `default-run` manifest key.")]
+    BinaryToRunNotDetermined,
+    #[error("Failed to locate project")]
+    CargoLocateProjectFailed,
+}
+
+/// Alias for a `Result` with the error type `hld::Error`.
+pub type Result<T> = result::Result<T, Error>;
+
+/// Extension trait for `io::Result`.
+pub trait IOResultExt<T> {
+    fn path_ctx<P: Into<PathBuf>>(self, path: P) -> Result<T>;
+}
+
+impl<T> IOResultExt<T> for io::Result<T> {
+    fn path_ctx<P: Into<PathBuf>>(self, path: P) -> Result<T> {
+        self.map_err(|source| Error::PathIo {
+            source,
+            path: path.into(),
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,174 +1,73 @@
-use serde::Deserialize;
-use std::fs;
-use std::os::unix::process::CommandExt;
-use std::process::{Command, Output};
-use std::str::{from_utf8, FromStr};
+#[macro_use]
+extern crate log;
 
-#[derive(Deserialize)]
-struct LocateProject {
-    root: String,
-}
+mod cli;
+mod error;
+mod util;
 
-fn samply_profile_default() -> toml::Value {
-    let inherits = toml::Value::String("release".to_owned());
-    let debug = toml::Value::Boolean(true);
-    toml::Value::Table(toml::Table::from_iter(vec![
-        ("inherits".to_string(), inherits),
-        ("debug".to_string(), debug),
-    ]))
-}
-fn print_command(command: &str, args: Vec<&str>) -> String {
-    let mut commandstr = command.to_owned();
-    for arg in args {
-        commandstr += " ";
-        if arg.contains(' ') {
-            commandstr += &format!("\"{}\"", arg);
-        } else {
-            commandstr += arg;
-        };
-    }
-    println!("running '{}'", &commandstr);
-    commandstr
-}
-fn run_command(command: &str, args: Vec<&str>) -> Output {
-    let commandstr = print_command(command, args.clone());
-    let output = Command::new(command)
-        .args(args)
-        .output()
-        .unwrap_or_else(|_| panic!("failed to run '{}'", commandstr));
+use std::process::Command;
+use std::vec;
 
-    if !output.status.success() {
-        if let Some(code) = &output.status.code() {
-            println!("'{}' failed with code '{}'", commandstr, code);
-            std::process::exit(*code);
-        }
-    }
-    output
-}
+use clap::Parser;
+
+use crate::util::{ensure_samply_profile, guess_bin, locate_project, CommandExt};
 
 fn main() {
-    // check if cargo.toml exists
-    // check project path using locate-project
-
-    let output = run_command("cargo", vec!["locate-project"]);
-    let result: Result<LocateProject, serde_json::Error> =
-        serde_json::from_str(from_utf8(&output.stdout).unwrap());
-
-    let cargo_toml: String;
-    if let Ok(result) = result {
-        cargo_toml = result.root;
-    } else {
-        println!("cargo locate-project: failed");
+    if let Err(err) = run() {
+        error!("{}", err);
         std::process::exit(1);
+    }
+}
+
+fn run() -> error::Result<()> {
+    let cli = cli::Config::parse();
+    ocli::init(if cli.verbose {
+        log::Level::Debug
+    } else {
+        log::Level::Info
+    })?;
+    if cli.bin.is_some() && cli.example.is_some() {
+        return Err(error::Error::BinAndExampleMutuallyExclusive);
     }
 
     // check if cargo.toml exists
-    println!("cargo.toml: {}", cargo_toml);
+    // check project path using locate-project
+    let cargo_toml = locate_project()?;
+    debug!("cargo.toml: {:?}", cargo_toml);
 
     // check if profile exists
     // if not add profile
     // if yes print warning
-
-    let binding: String = fs::read_to_string(&cargo_toml)
-        .unwrap_or_else(|_| panic!("failed reading '{}'", &cargo_toml));
-    let cargo_toml_content = binding.as_str();
-
-    let mut manifest_toml = toml::Table::from_str(cargo_toml_content).unwrap();
-
-    let profile = manifest_toml
-        .entry("profile")
-        .or_insert(toml::Value::Table(toml::Table::new()));
-
-    profile
-        .as_table_mut()
-        .expect("profile is not a table")
-        .entry("samply")
-        .or_insert(samply_profile_default())
-        .as_table()
-        .expect("should never fail");
-
-    let manifest = manifest_toml.to_string();
-
-    if manifest != cargo_toml_content {
-        println!("'samply' profile was added to 'Cargo.toml'");
-        fs::write(&cargo_toml, manifest).expect("writing to 'Cargo.toml' failed");
+    if cli.profile == "samply" {
+        ensure_samply_profile(&cargo_toml)?;
     }
 
-    // find the currently build binary name
-    let mut manifest =
-        cargo_toml::Manifest::from_str(cargo_toml_content).expect("failed parsing 'Cargo.toml'");
-
-    manifest
-        .complete_from_path(std::path::Path::new(&cargo_toml))
-        .expect("completing manifest failed");
-
-    // first we find the available binaries
-    let binaries = manifest.bin;
-    if binaries.is_empty() {
-        println!("no binary found in 'Cargo.toml'");
-        std::process::exit(1);
-    }
-    // if length equal to one then we use it
-    let def_binary_name = manifest
-        .package
-        .expect("no package section")
-        .default_run
-        .unwrap_or(
-            binaries
-                .first()
-                .and_then(|s| s.name.clone())
-                .expect("no binaries in the package"),
-        );
-
-    // parse additional arguments from the command line
-    let args = std::env::args().collect::<Vec<String>>();
-    let args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-
-    // if args contains -- we split into two arg blocks
-    let (add_build_args, bin_args) = {
-        let mut split = args.split(|&s| s == "--");
-        let a = split.next().unwrap().to_owned();
-        let b = split.next().unwrap_or(&[]).to_owned();
-        (a, b)
-    };
-
-    let mut build_args: Vec<&str> = vec!["build", "--profile", "samply"];
-
-    let binary_name = if let Some((idx, _)) = add_build_args
-        .iter()
-        .enumerate()
-        .find(|(_, &s)| s == "--bin")
-    {
-        if let Some(arg) = add_build_args.get(idx + 1) {
-            build_args.push("--bin");
-            build_args.push(add_build_args[idx + 1]);
-            "target/samply/".to_string() + &arg
-        } else {
-            println!("--bin requires an argument");
-            std::process::exit(1);
-        }
-    } else if let Some((idx, _)) = add_build_args
-        .iter()
-        .enumerate()
-        .find(|(_, &s)| s == "--example")
-    {
-        let arg = add_build_args[idx + 1];
-
-        build_args.push("--example");
-        build_args.push(add_build_args[idx + 1]);
-        "target/samply/examples/".to_string() + arg
+    let (bin_opt, bin_name) = if let Some(bin) = cli.bin {
+        ("--bin", bin)
+    } else if let Some(example) = cli.example {
+        ("--example", example)
     } else {
-        "target/samply/".to_string() + &def_binary_name
+        ("--bin", guess_bin(&cargo_toml)?)
     };
 
-    // run cargo build with the samply profile
-    // if it fails print error
-    run_command("cargo", build_args);
+    let mut args = vec!["build", "--profile", &cli.profile, &bin_opt, &bin_name];
+    if let Some(features) = cli.features.as_ref() {
+        args.push("--features");
+        args.push(features);
+    }
+    if cli.no_default_features {
+        args.push("--no-default-features");
+    }
+    let exit_code = Command::new("cargo").args(args).call()?;
+    if !exit_code.success() {
+        return Err(error::Error::CargoBuildFailed);
+    }
 
     // run samply on the binary
     // if it fails print error
-    let mut samply_args = vec!["record", &binary_name];
-    samply_args.extend(bin_args.iter());
-    print_command("samply", samply_args.clone());
-    Command::new("samply").args(samply_args).exec();
+    let root = cargo_toml.parent().unwrap();
+    let bin_path = root.join("target").join(&cli.profile).join(&bin_name);
+    Command::new("samply").arg("record").arg(bin_path).call()?;
+
+    Ok(())
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,82 @@
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    process::{Command, ExitStatus},
+    str::{from_utf8, FromStr},
+};
+
+use crate::error::{self, IOResultExt};
+
+pub fn locate_project() -> error::Result<PathBuf> {
+    let output = Command::new("cargo")
+        .args(vec![
+            "locate-project",
+            "--workspace",
+            "--message-format",
+            "plain",
+        ])
+        .log()
+        .output()?;
+    if !output.status.success() {
+        return Err(error::Error::CargoLocateProjectFailed);
+    }
+    Ok(PathBuf::from(from_utf8(&output.stdout)?.trim()))
+}
+
+const SAMPLY_PROFILE: &str = "
+[profile.samply]
+inherits = \"release\"
+debug = true
+";
+
+pub fn ensure_samply_profile(cargo_toml: &Path) -> error::Result<()> {
+    let cargo_toml_content: String = fs::read_to_string(cargo_toml).path_ctx(cargo_toml)?;
+    let manifest = toml::Table::from_str(&cargo_toml_content)?;
+    let profile_samply = manifest
+        .get("profile")
+        .and_then(|p| p.as_table())
+        .and_then(|p| p.get("samply"));
+
+    if profile_samply.is_none() {
+        let mut f = OpenOptions::new().append(true).open(&cargo_toml).unwrap();
+        f.write(SAMPLY_PROFILE.as_bytes()).path_ctx(&cargo_toml)?;
+        info!("'samply' profile was added to 'Cargo.toml'");
+    }
+    Ok(())
+}
+
+pub fn guess_bin(cargo_toml: &Path) -> error::Result<String> {
+    let manifest = cargo_toml::Manifest::from_path(&cargo_toml)?;
+    let default_run = manifest.package.and_then(|p| p.default_run);
+    if let Some(bin) = default_run {
+        return Ok(bin);
+    } else if manifest.bin.len() == 1 {
+        return Ok(manifest.bin.first().unwrap().name.clone().unwrap());
+    } else if manifest.bin.len() == 0 {
+        return Err(error::Error::NoBinaryFound);
+    } else {
+        return Err(error::Error::BinaryToRunNotDetermined);
+    }
+}
+
+/// Extension trait for `Command` that add a `call` method which logs the command in debug mode.
+pub trait CommandExt {
+    fn call(&mut self) -> error::Result<ExitStatus>;
+    fn log(&mut self) -> &mut Command;
+}
+
+impl CommandExt for Command {
+    fn call(&mut self) -> error::Result<ExitStatus> {
+        self.log();
+        Ok(self.spawn()?.wait()?)
+    }
+    fn log(&mut self) -> &mut Command {
+        debug!(
+            "running {:?} with args: {:?}",
+            self.get_program(),
+            self.get_args().collect::<Vec<&std::ffi::OsStr>>()
+        );
+        self
+    }
+}


### PR DESCRIPTION
As proposed in #2 I've reworked the command line management with `clap`.

During that task I got a bit (too) enthusiastic and also changed how the errors are dealt with and ended changing quite a lot of things. Just pick what you like, if you like anything of what has been done :-)

I've changed the behavior as little as possible, however I've updated a few things to match my own needs:
* make it work in a workspace
* added the `--features` and `--no-default-features` flags
* display cargo build output during the build
* display debug information (like the Cargo.toml path) only when using `--verbose`
* only append the samply profile at the end of the`Cargo.toml` in order to avoid loosing the comments or changing how it is formatted