### PR TITLE
Fix consumption/passing-forward of CLI args

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,10 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Config {
+    /// Cargo passes the sub-command's own name as first argument, which we don't care about.
+    #[arg(hide = true, value_parser = clap::builder::PossibleValuesParser::new(["samply"]))]
+    pub dummy: Option<String>,
+
     /// Trailing arguments passed to the binary being profiled
     #[arg(name = "TRAILING_ARGUMENTS")]
     pub args: Vec<String>,

--- a/tests/args/Cargo.toml
+++ b/tests/args/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "args"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[profile.samply]
+inherits = "release"
+debug = true

--- a/tests/args/src/main.rs
+++ b/tests/args/src/main.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let args = std::env::args();
+
+    let args_without_binary_path: Vec<String> = args.skip(1).collect();
+
+    println!("{args_without_binary_path:#?}",);
+    assert!(args_without_binary_path.is_empty());
+}


### PR DESCRIPTION
Running …

```terminal
cargo samply -- --foo bar
```

… on a project like …

```rust
fn main() {
    println!("{:#?}", std::env::args().collect::<Vec<_>>());
}
```

… results in superfluous and inadvertent passing of a leading `samply` argument to the binary being sampled.

Expected output:

```rust
[
    "…/dummy/target/samply/dummy",
    "--foo",
    "bar",
]
```

Actual output:

```rust
[
    "…/dummy/target/samply/dummy",
    "samply",
    "--foo",
    "bar",
]
```

---

One way to resolve this with `clap` is to [wrap the entire CLI into a dummy "samply" command](https://github.com/clap-rs/clap/issues/937), the other is to add a hidden, leading positional dummy "samply" argument.

The latter allows for use via `cargo samply …` and `cargo-samply …`