### PR TITLE
use "`=`" with `--samply-args` throughout docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `--test <NAME>` flag to profile integration tests and test binaries.
-- `--samply-args <ARGS>` flag to pass arguments directly to `samply` (e.g., `--samply-args "--rate 2000"`).
+- `--samply-args <ARGS>` flag to pass arguments directly to `samply` (e.g., `--samply-args="--rate 2000"`).
 - `-p, --package <PKG>` flag to select a package in a workspace (aligns with standard Cargo conventions).
 - Proactive `samply` installation check before starting the build, providing earlier feedback if `samply` is missing.
 - Test targets are now discoverable via `--list-targets`.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ cargo samply --no-default-features
 cargo samply -- arg1 arg2 --flag value
 
 # Pass arguments to samply (e.g., set sample rate)
-# "=" is needed to prevent cargo from trying to parse "--rate 2000"
+# Use "=" so "--rate 2000" is treated as the value of --samply-args
 cargo samply --samply-args="--rate 2000" --bin my-binary
 
 # Run without starting samply (useful for debugging build/target selection)
@@ -159,7 +159,8 @@ cargo samply --samply-args="--rate 2000" --bin my-binary
 cargo samply --samply-args="--rate 2000 --save-only profile.json" --bin my-binary
 ```
 
-Use "=" to prevent cargo from trying to parse the samply arguments.
+Use "=" so the full string is treated as the value of `--samply-args`, even
+when it starts with `--`.
 
 #### Selecting a package in a workspace (`-p, --package`)
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Options:
       --bench <BENCH>              Benchmark target to run (e.g. `cargo samply --bench throughput`)
       --test <TEST>                Test target to run (e.g. `cargo samply --test integration_test`)
       --bench-flag <BENCH_FLAG>    The flag to use when running the benchmark target [default: --bench]
-      --samply-args <SAMPLY_ARGS>  Arguments to pass to samply (e.g. `--samply-args "--rate 2000"`)
+      --samply-args <SAMPLY_ARGS>  Arguments to pass to samply (e.g. `--samply-args="--rate 2000"`)
   -f, --features <FEATURES>        Build features to enable
       --no-default-features        Disable default features
   -v, --verbose                    Print extra output to help debug problems
@@ -119,7 +119,8 @@ cargo samply --no-default-features
 cargo samply -- arg1 arg2 --flag value
 
 # Pass arguments to samply (e.g., set sample rate)
-cargo samply --samply-args "--rate 2000" --bin my-binary
+# "=" is needed to prevent cargo from trying to parse "--rate 2000"
+cargo samply --samply-args="--rate 2000" --bin my-binary
 
 # Run without starting samply (useful for debugging build/target selection)
 cargo samply --no-samply
@@ -152,11 +153,13 @@ Pass additional arguments directly to `samply`:
 
 ```bash
 # Set sample rate
-cargo samply --samply-args "--rate 2000" --bin my-binary
+cargo samply --samply-args="--rate 2000" --bin my-binary
 
 # Pass multiple samply options
-cargo samply --samply-args "--rate 2000 --save-only profile.json" --bin my-binary
+cargo samply --samply-args="--rate 2000 --save-only profile.json" --bin my-binary
 ```
+
+Use "=" to prevent cargo from trying to parse the samply arguments.
 
 #### Selecting a package in a workspace (`-p, --package`)
 

--- a/openspec/changes/archive/2025-12-27-improve-robustness-and-ux/proposal.md
+++ b/openspec/changes/archive/2025-12-27-improve-robustness-and-ux/proposal.md
@@ -15,7 +15,7 @@ Analysis of the current codebase revealed several issues affecting robustness an
 - **UX**: `--dry-run` now emits properly quoted, copy-pasteable shell commands.
 - **Features**: 
   - Add `--test <NAME>` support.
-  - Allow passing arguments to `samply` (e.g., `cargo samply --samply-args "--rate 2000" ...`).
+  - Allow passing arguments to `samply` (e.g., `cargo samply --samply-args="--rate 2000" ...`).
   - Proactively check for `samply` installation.
 
 ## Impact

--- a/openspec/changes/archive/2025-12-27-improve-robustness-and-ux/specs/cli/spec.md
+++ b/openspec/changes/archive/2025-12-27-improve-robustness-and-ux/specs/cli/spec.md
@@ -24,7 +24,7 @@ The CLI SHALL support profiling integration tests via a `--test` flag.
 The CLI SHALL allow passing arguments directly to the `samply` process.
 
 #### Scenario: User sets sample rate
-- **WHEN** user runs `cargo samply --samply-args "--rate 2000" --bin app`
+- **WHEN** user runs `cargo samply --samply-args="--rate 2000" --bin app`
 - **THEN** `samply` is invoked with `--rate 2000`
 
 ### Requirement: Shell-Compatible Dry-Run

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -27,7 +27,7 @@ The CLI SHALL support profiling integration tests via a `--test` flag.
 The CLI SHALL allow passing arguments directly to the `samply` process.
 
 #### Scenario: User sets sample rate
-- **WHEN** user runs `cargo samply --samply-args "--rate 2000" --bin app`
+- **WHEN** user runs `cargo samply --samply-args="--rate 2000" --bin app`
 - **THEN** `samply` is invoked with `--rate 2000`
 
 ### Requirement: Shell-Compatible Dry-Run

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -104,7 +104,9 @@ pub struct Config {
     #[arg(long, default_value = "--bench")]
     pub bench_flag: String,
 
-    /// Arguments to pass to samply (e.g. `--samply-args "--rate 2000"`)
+    /// Arguments to pass to samply (e.g. `--samply-args="--rate 2000"`).
+    /// Use "=" to prevent cargo from trying to parse the arguments meant for
+    /// samply.
     #[arg(long)]
     pub samply_args: Option<String>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,8 +105,8 @@ pub struct Config {
     pub bench_flag: String,
 
     /// Arguments to pass to samply (e.g. `--samply-args="--rate 2000"`).
-    /// Use "=" to prevent cargo from trying to parse the arguments meant for
-    /// samply.
+    /// Use `=` so the full string is parsed as the value of `--samply-args`,
+    /// even when it starts with `--`.
     #[arg(long)]
     pub samply_args: Option<String>,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,10 @@
 //! You can also pass arguments directly to `samply` itself:
 //!
 //! ```console
-//! $ cargo samply --samply-args "--rate 2000" --bin my-binary
+//! $ cargo samply --samply-args="--rate 2000" --bin my-binary
 //! ```
+//! 
+//! "=" is needed here to prevent cargo from trying to parse "--rate 2000".
 //!
 //! ### Workspaces
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,9 @@
 //! ```console
 //! $ cargo samply --samply-args="--rate 2000" --bin my-binary
 //! ```
-//! 
-//! "=" is needed here to prevent cargo from trying to parse "--rate 2000".
+//!
+//! Use `=` so the full `--rate 2000` string is treated as the value of
+//! `--samply-args`, rather than as separate flags.
 //!
 //! ### Workspaces
 //!

--- a/tests/samply-args.trycmd
+++ b/tests/samply-args.trycmd
@@ -11,3 +11,16 @@ cargo build '--message-format=json-diagnostic-rendered-ansi' --profile samply --
 [..]record --rate 2000 --save-only profile.json -- [..]target[..]samply[..]samply-args[..]
 
 ```
+
+```console
+$ cargo-samply samply --samply-args "--rate 2000" --dry-run
+? 2
+error: unexpected argument '--rate 2000' found
+
+  tip: to pass '--rate 2000' as a value, use '-- --rate 2000'
+
+Usage: cargo samply [OPTIONS] [TRAILING_ARGUMENTS]...
+
+For more information, try '--help'.
+
+```


### PR DESCRIPTION
I am finding on Windows that I need to pass `--samply-args` arguments using "`=`" (e.g., `--samply-args="--rate 2000"`) to prevent cargo from trying to parse the arguments meant for samply. This PR updates the documentation to explicitly mention this.
